### PR TITLE
Properly return thumb and full size urls for multiple images from the same service in one post.

### DIFF
--- a/libs/spazimageurl.js
+++ b/libs/spazimageurl.js
@@ -163,7 +163,10 @@ SpazImageURL.prototype.findServiceUrlsInString = function(str) {
 		sch.dump(thisapi.url_regex);
 		while( (re_matches = thisapi.url_regex.exec(sch.trim(str))) != null) {
 			sch.dump(re_matches);
-			matches[key] = re_matches;
+			if(!matches[key]) {
+				matches[key] = [];
+			}
+			matches[key].push(re_matches);
 			num_matches++;
 		}
 	}
@@ -191,8 +194,11 @@ SpazImageURL.prototype.getThumbsForMatches = function(matches) {
 		api = this.getAPI(service);
 		urls = matches[service]; // an array
 		sch.dump("URLS:"+urls);
-		thumburls[urls[0]] = api.getThumbnailUrl(urls[1]);
-		num_urls++;
+		for (var i = 0; i < urls.length; i++) {
+			var url = urls[i];
+			thumburls[url[0]] = api.getThumbnailUrl(url[1]);
+			num_urls++;
+		}
 	}
 
 	sch.dump('num_urls:'+num_urls);
@@ -251,8 +257,11 @@ SpazImageURL.prototype.getImagesForMatches = function(matches) {
 		api = this.getAPI(service);
 		urls = matches[service]; // an array
 		sch.dump("URLS:"+urls);
-		imageurls[urls[0]] = api.getImageUrl(urls[1]);
-		num_urls++;
+		for (var i = 0; i < urls.length; i++) {
+			var url = urls[i];
+			imageurls[url[0]] = api.getImageUrl(url[1]);
+			num_urls++;
+		}
 	}
 
 	sch.dump('num_urls:'+num_urls);

--- a/tests/library_tests.js
+++ b/tests/library_tests.js
@@ -84,9 +84,10 @@ $().ready(function() {
 		same(JSON.stringify(result), JSON.stringify(expect));
 	
 	
-		foo = "http://twitpic.com/gr2p5 - \"I'm giving the catapault 18 AC.\" RT @coffeemaverick: This kid we call \"Monkey Boy\" in Hawaii.His story tomorrow at Coffeemaverick.com #fb http://yfrog.com/12obqj. 5 rows from the wil wheaton panel http://twitgoo.com/36cg2  http://pikchur.com/Gp0 - waaah! my face is too big. lol http://tweetphoto.com/1de714 Me & Jenn at the Del Mar track Friday. Had a blast I just voted for http://pic.gd/b4b8eb Check it out! #TweetPhoto";
+		foo = "http://twitpic.com/gr2p5 http://twitpic.com/51if4t - \"I'm giving the catapault 18 AC.\" RT @coffeemaverick: This kid we call \"Monkey Boy\" in Hawaii.His story tomorrow at Coffeemaverick.com #fb http://yfrog.com/12obqj. 5 rows from the wil wheaton panel http://twitgoo.com/36cg2  http://pikchur.com/Gp0 - waaah! my face is too big. lol http://tweetphoto.com/1de714 Me & Jenn at the Del Mar track Friday. Had a blast I just voted for http://pic.gd/b4b8eb Check it out! #TweetPhoto";
 		expect = {
 						"http://twitpic.com/gr2p5"     : "http://twitpic.com/show/thumb/gr2p5",
+						"http://twitpic.com/51if4t"    : "http://twitpic.com/show/thumb/51if4t",
 						"http://yfrog.com/12obqj"      : "http://yfrog.com/12obqj.th.jpg",
 						"http://twitgoo.com/36cg2"     : "http://twitgoo.com/show/thumb/36cg2",
 						"http://pikchur.com/Gp0"       : "http://img.pikchur.com/pic_Gp0_s.jpg",
@@ -104,7 +105,15 @@ $().ready(function() {
 		};
 		result = siu.getThumbsForUrls(foo);
 		same(JSON.stringify(result), JSON.stringify(expect));
-	
+		
+		
+		foo = "Alice says my beautiful plant's still going strong, love from Australia! http://twitpic.com/51ieyo http://twitpic.com/51if4t";
+		expect = {
+						"http://twitpic.com/51ieyo"     : "http://twitpic.com/show/large/51ieyo",
+						"http://twitpic.com/51if4t"    : "http://twitpic.com/show/large/51if4t"
+		};
+		result = siu.getImagesForUrls(foo);
+		same(JSON.stringify(result), JSON.stringify(expect));
 	});
 	
 	


### PR DESCRIPTION
This was working before with multiple images as long as you only had one image from each service.

I modified one of the getThumbsForUrls() tests to have two twitpic urls, and also added a test for getImagesForUrls().
